### PR TITLE
Update Go URLs

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get upgrade -y
 
 RUN apt-get install -y curl build-essential git-core bzr mercurial
 
-ENV GO_VERSION 1.2
-RUN mkdir -p /opt/ && cd /opt/ && curl -SsfL http://go.googlecode.com/files/go$GO_VERSION.linux-amd64.tar.gz | tar xfz -
+ENV GO_VERSION 1.10
+RUN mkdir -p /opt/ && cd /opt/ && curl -SsfL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xfz -
 
 RUN mkdir /go
 

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get upgrade -y
 RUN apt-get install -y curl build-essential git-core bzr mercurial
 
 ENV GO_VERSION 1.10
-RUN mkdir -p /opt/ && cd /opt/ && curl -SsfL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xfz -
+RUN mkdir -p /opt/ && cd /opt/ && curl -SsfL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xfz - \
+  && ln -s /opt/go/bin/go /usr/local/bin/go
 
 RUN mkdir /go
 


### PR DESCRIPTION
- Update Go to 1.10
- Symlink the Go binary into the Ubuntu Path